### PR TITLE
Duplicate release builds to beta channel

### DIFF
--- a/buildhub/ingest/sqs.py
+++ b/buildhub/ingest/sqs.py
@@ -146,7 +146,7 @@ def process_buildhub_json_key(config, s3):
         # This is a hack to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1470948
         # In some future world we might be able to architecture buildhub in such a way
         # where this sort of transformation isn't buried down deep in the code
-        if build["target"]["channel"] == "release":
+        if build["source"]["product"] == "firefox" and build["target"]["channel"] == "release":
             beta_build = deepcopy(build)
             beta_build["target"]["channel"] = "beta"
             ret = Build.insert(

--- a/buildhub/ingest/sqs.py
+++ b/buildhub/ingest/sqs.py
@@ -145,7 +145,7 @@ def process_buildhub_json_key(config, s3):
         inserted.append(ret)
         # This is a hack to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1470948
         # In some future world we might be able to architecture buildhub in such a way
-        # where this sort of transformation isn't buried down deep in the code.
+        # where this sort of transformation isn't buried down deep in the code
         if build["target"]["channel"] == "release":
             beta_build = deepcopy(build)
             beta_build["target"]["channel"] = "beta"

--- a/buildhub/ingest/sqs.py
+++ b/buildhub/ingest/sqs.py
@@ -166,7 +166,9 @@ def process_buildhub_json_key(config, s3):
             f"Validation error message: {exc.message}"
         )
         raise
-    if inserted:
+    # Build.insert() above can return None (for Builds that already exist).
+    # If anything was _actually_ inserted, log it.
+    if any(inserted):
         for i in inserted:
             metrics.incr("sqs_inserted")
             logger.info(f"Inserted {key_name} as a valid Build ({i.build_hash})")

--- a/buildhub/ingest/sqs.py
+++ b/buildhub/ingest/sqs.py
@@ -143,6 +143,9 @@ def process_buildhub_json_key(config, s3):
             s3_object_etag=s3["object"]["eTag"],
         )
         inserted.append(ret)
+        # This is a hack to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1470948
+        # In some future world we might be able to architecture buildhub in such a way
+        # where this sort of transformation isn't buried down deep in the code.
         if build["target"]["channel"] == "release":
             beta_build = deepcopy(build)
             beta_build["target"]["channel"] = "beta"

--- a/buildhub/ingest/sqs.py
+++ b/buildhub/ingest/sqs.py
@@ -146,7 +146,10 @@ def process_buildhub_json_key(config, s3):
         # This is a hack to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1470948
         # In some future world we might be able to architecture buildhub in such a way
         # where this sort of transformation isn't buried down deep in the code
-        if build["source"]["product"] == "firefox" and build["target"]["channel"] == "release":
+        if (
+            build["source"]["product"] == "firefox"
+            and build["target"]["channel"] == "release"
+        ):
             beta_build = deepcopy(build)
             beta_build["target"]["channel"] = "beta"
             ret = Build.insert(

--- a/buildhub/settings.py
+++ b/buildhub/settings.py
@@ -352,6 +352,8 @@ class Localdev(Base):
 
     LOGGING_USE_JSON = values.BooleanValue(False)
 
+    UNSIGNED_S3_CLIENT = values.BooleanValue(False)
+
     @property
     def VERSION(self):
         fn = os.path.join(self.BASE_DIR, "version.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,11 @@ def valid_build_release_channel():
 
 
 @pytest.fixture
+def valid_build_fennec_release_channel():
+    return partial(_load, "valid-buildhub-fennec-release-channel.json")
+
+
+@pytest.fixture
 def elasticsearch(request):
     """Returns the index object for builds. But before, it re-creates the index.
     And after the index is deleted. All 404s ignored.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,11 @@ def valid_build():
 
 
 @pytest.fixture
+def valid_build_release_channel():
+    return partial(_load, "valid-buildhub-release-channel.json")
+
+
+@pytest.fixture
 def elasticsearch(request):
     """Returns the index object for builds. But before, it re-creates the index.
     And after the index is deleted. All 404s ignored.

--- a/tests/test_ingest_sqs.py
+++ b/tests/test_ingest_sqs.py
@@ -136,6 +136,65 @@ def test_start_happy_path_release_channel(mocked_boto3, settings, valid_build_re
 
 @pytest.mark.django_db
 @mock.patch("buildhub.ingest.sqs.boto3")
+def test_start_happy_path_fennec_release_channel(mocked_boto3, settings, valid_build_fennec_release_channel, itertools_count, mocker):
+    mocked_message = mocker.MagicMock()
+    # See
+    # https://gist.github.com/peterbe/f739b91c0674d36a1526ccb43b6844c3#file-stage-json
+    # for a real life example of a SQS message.
+    message = {
+        "Message": json.dumps(
+            {
+                "Records": [
+                    {"foot": "here"},
+                    {
+                        "s3": {
+                            "object": {
+                                "key": "some/path/to/buildhub.json",
+                                "eTag": "e4eb6609382efd6b3bc9deec616ad5c0",
+                            },
+                            "bucket": {"name": "buildhubses"},
+                        }
+                    },
+                    {
+                        "s3": {
+                            "object": {
+                                "key": "not/a/buildhub.json/file",
+                                "eTag": "77e09ba7e37836c2cf0ce59e1e8361ab",
+                            },
+                            "bucket": {"name": "buildhubses"},
+                        }
+                    },
+                ]
+            }
+        )
+    }
+    mocked_message.body = json.dumps(message)
+    mocked_queue = mocker.MagicMock()
+    mocked_queue.receive_messages().__iter__.return_value = [mocked_message]
+    mocked_boto3.resource().get_queue_by_name.return_value = mocked_queue
+
+    mocked_s3_client = mocker.MagicMock()
+    mocked_boto3.client.return_value = mocked_s3_client
+
+    def mocked_download_fileobj(bucket_name, key_name, f):
+        # Sanity checks that the mocking is right
+        assert bucket_name == "buildhubses"
+        assert key_name == "some/path/to/buildhub.json"
+        f.write(json.dumps(valid_build_fennec_release_channel()).encode("utf-8"))
+
+    mocked_s3_client.download_fileobj.side_effect = mocked_download_fileobj
+    start(settings.SQS_QUEUE_URL)
+    mocked_boto3.resource().get_queue_by_name.assert_called_with(
+        QueueName="buildhub-s3-events"
+    )
+    # It should have created 1 Builds
+    assert Build.objects.all().count() == 1
+
+    mocked_boto3.client.assert_called_with("s3", "ca-north-2", config=mock.ANY)
+
+
+@pytest.mark.django_db
+@mock.patch("buildhub.ingest.sqs.boto3")
 def test_records_legacy_message(
     mocked_boto3, settings, valid_build, itertools_count, mocker
 ):

--- a/tests/test_ingest_sqs.py
+++ b/tests/test_ingest_sqs.py
@@ -76,7 +76,10 @@ def test_start_happy_path(mocked_boto3, settings, valid_build, itertools_count, 
 
 @pytest.mark.django_db
 @mock.patch("buildhub.ingest.sqs.boto3")
-def test_start_happy_path_release_channel(mocked_boto3, settings, valid_build_release_channel, itertools_count, mocker):
+def test_start_happy_path_release_channel(
+    mocked_boto3, settings, valid_build_release_channel, itertools_count, mocker
+):
+
     mocked_message = mocker.MagicMock()
     # See
     # https://gist.github.com/peterbe/f739b91c0674d36a1526ccb43b6844c3#file-stage-json
@@ -136,7 +139,10 @@ def test_start_happy_path_release_channel(mocked_boto3, settings, valid_build_re
 
 @pytest.mark.django_db
 @mock.patch("buildhub.ingest.sqs.boto3")
-def test_start_happy_path_fennec_release_channel(mocked_boto3, settings, valid_build_fennec_release_channel, itertools_count, mocker):
+def test_start_happy_path_fennec_release_channel(
+    mocked_boto3, settings, valid_build_fennec_release_channel, itertools_count, mocker
+):
+
     mocked_message = mocker.MagicMock()
     # See
     # https://gist.github.com/peterbe/f739b91c0674d36a1526ccb43b6844c3#file-stage-json

--- a/tests/valid-buildhub-fennec-release-channel.json
+++ b/tests/valid-buildhub-fennec-release-channel.json
@@ -1,0 +1,30 @@
+{
+    "build": {
+        "as": "/builds/worker/workspace/build/src/clang/bin/clang -std=gnu99 --target=x86_64-linux-android",
+        "cc": "/builds/worker/workspace/build/src/clang/bin/clang -std=gnu99 --target=x86_64-linux-android",
+        "cxx": "/builds/worker/workspace/build/src/clang/bin/clang++ --target=x86_64-linux-android",
+        "date": "2019-08-29T13:44:13Z",
+        "host": "x86_64-pc-linux-gnu",
+        "id": "20190829134413",
+        "target": "x86_64-pc-linux-android"
+    },
+    "download": {
+        "date": "2019-08-29T19:02:21.129666+00:00",
+        "mimetype": "application/octet-stream",
+        "size": 50637944,
+        "url": "https://archive.mozilla.org/pub/mobile/candidates/68.1-candidates/build1/android-x86_64/en-US/fennec-68.1.en-US.android-x86_64.apk"
+    },
+    "source": {
+        "product": "fennec",
+        "repository": "https://hg.mozilla.org/releases/mozilla-esr68",
+        "revision": "46d112299d475ffd9ef1c598f1ddb2ff3eec3360",
+        "tree": "mozilla-esr68"
+    },
+    "target": {
+        "channel": "release",
+        "locale": "en-US",
+        "os": "android",
+        "platform": "android-x86_64",
+        "version": "68.1"
+    }
+}

--- a/tests/valid-buildhub-release-channel.json
+++ b/tests/valid-buildhub-release-channel.json
@@ -1,0 +1,30 @@
+{
+    "build": {
+        "as": "z:/task_1571244707/build/src/vs2017_15.8.4/VC/bin/HostX64/x64/ml64.exe",
+        "cc": "z:/task_1571244707/fetches/clang/bin/clang-cl.exe -Xclang -std=gnu99",
+        "cxx": "z:/task_1571244707/fetches/clang/bin/clang-cl.exe",
+        "date": "2019-10-16T16:19:57Z",
+        "host": "x86_64-pc-mingw32",
+        "id": "20191016161957",
+        "target": "x86_64-pc-mingw32"
+    },
+    "download": {
+        "date": "2019-10-16T21:24:22.032307+00:00",
+        "mimetype": "application/octet-stream",
+        "size": 51516392,
+        "url": "https://archive.mozilla.org/pub/firefox/candidates/70.0-candidates/build2/win64/en-US/Firefox%20Setup%2070.0.exe"
+    },
+    "source": {
+        "product": "firefox",
+        "repository": "https://hg.mozilla.org/releases/mozilla-release",
+        "revision": "990d9f90f0f5c02b8af12d784dc76ab40ea84781",
+        "tree": "mozilla-release"
+    },
+    "target": {
+        "channel": "release",
+        "locale": "en-US",
+        "os": "win",
+        "platform": "win64",
+        "version": "70.0"
+    }
+}


### PR DESCRIPTION
This should fix https://bugzilla.mozilla.org/show_bug.cgi?id=1470948.

It's a pretty brain-dead way of doing it -- we simply check the channel of every buildhub.json we find, and if it's "release", we make a second entry with the same data, except we set channel to "beta".

In addition to the new unit test, I also managed to get injestion running locally, and verify it that way. Eg:
![image](https://user-images.githubusercontent.com/49649/67428670-971dbf80-f5ac-11e9-962f-7fdd95434e70.png)
