### PR TITLE
Improve error logging in rebuild-bigquery management command.

### DIFF
--- a/buildhub/main/management/commands/rebuild-bigquery.py
+++ b/buildhub/main/management/commands/rebuild-bigquery.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
             errors = client.insert_rows(table, rows)
             for error in errors:
                 error_count += 1
-                logging.warning(error)
+                logger.warning("Errors in row %s: %s", error["index"], error["errors"])
                 if error_count >= max_error_count:
                     raise Exception(
                         "encountered max number of errors: {error_count}/count"


### PR DESCRIPTION
The log message shoud go to `logger` instead of using the root logger with `logging.warn()`. Moreover, the error mapping returned by the BigQuery client lib wasn't converted to a string for some reason, so the logging messages ended up empty. With this change applied, we can see the actual error messages, which all look like this:

    {"Timestamp": 1585240078001619968, "Type": "buildhub", "Logger": "buildhub", "Hostname": "buildhub2-stage-buildhub2-app-1-6fff5c45f9-2kfb6", "EnvVersion": "2.0", "Severity": 4, "Pid": 95, "Fields": {"msg": "Errors in row 7: [{'reason': 'invalid', 'location': '', 'debugInfo': '', 'message': 'Value 1542846590169000 for field created_at of the destination table moz-fx-buildhub2-nonprod-019e:build_metadata.buildhub2 is outside the allowed bounds. You can only stream to date range within 365 days in the past and 183 days in the future relative to the current date.'}]"}}