### PR TITLE
Use a separate timestamp for submission into BigQuery

### DIFF
--- a/buildhub/main/bigquery.py
+++ b/buildhub/main/bigquery.py
@@ -26,6 +26,7 @@ BQ_SCHEMA = [
     {"name": "created_at", "type": "TIMESTAMP", "mode": "REQUIRED"},
     {"name": "s3_object_key", "type": "STRING", "mode": "NULLABLE"},
     {"name": "s3_object_etag", "type": "STRING", "mode": "NULLABLE"},
+    {"name": "submission_timestamp", "type": "TIMESTAMP", "mode": "REQUIRED"},
 ]
 
 
@@ -38,7 +39,7 @@ def create_table(client, table):
     schema = client.schema_from_json(get_schema_file_object())
     table = bigquery.table.Table(table, schema)
     table.time_partitioning = bigquery.TimePartitioning(
-        type_=bigquery.TimePartitioningType.DAY, field="created_at"
+        type_=bigquery.TimePartitioningType.DAY, field="submission_timestamp"
     )
     return client.create_table(table)
 

--- a/buildhub/main/models.py
+++ b/buildhub/main/models.py
@@ -5,6 +5,7 @@
 import hashlib
 import json
 import os
+import time
 
 import yaml
 from django.conf import settings
@@ -47,8 +48,11 @@ class Build(models.Model):
     def to_search(self, **kwargs):
         return BuildDoc.create(self.id, **self.build)
 
-    def to_dict(self):
-        return json.loads(serialize("json", [self]))[0]["fields"]
+    def to_dict(self, with_timestamp=True):
+        data = json.loads(serialize("json", [self]))[0]["fields"]
+        if with_timestamp:
+            data["submission_timestamp"] = time.time()
+        return data
 
     hash_prefix = "v1"
 

--- a/tests/test_main_models.py
+++ b/tests/test_main_models.py
@@ -55,6 +55,7 @@ def test_model_serialization(valid_build):
         "created_at",
         "s3_object_key",
         "s3_object_etag",
+        "submission_timestamp"
     }
 
 

--- a/tests/test_main_models.py
+++ b/tests/test_main_models.py
@@ -55,7 +55,7 @@ def test_model_serialization(valid_build):
         "created_at",
         "s3_object_key",
         "s3_object_etag",
-        "submission_timestamp"
+        "submission_timestamp",
     }
 
 


### PR DESCRIPTION
Based on #623, it looks like the database contains `created_at` timestamps that are older than a year. To address this, I've added a separate `submission_timestamp` field, which is appended before the payload is sent to BigQuery. This is used as a partitioning key within BigQuery, and will be updated every time a rebuild is done.

