### PR TITLE
Add missing dockerflow metadata to bigquery schema

### DIFF
--- a/buildhub/main/bigquery.py
+++ b/buildhub/main/bigquery.py
@@ -21,7 +21,12 @@ BQ_SCHEMA = [
         "name": "metadata",
         "type": "RECORD",
         "mode": "NULLABLE",
-        "fields": [{"name": "version", "type": "STRING", "mode": "NULLABLE"}],
+        "fields": [
+            {"name": "commit", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "version", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "source", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "build", "type": "STRING", "mode": "NULLABLE"},
+        ],
     },
     {"name": "created_at", "type": "TIMESTAMP", "mode": "REQUIRED"},
     {"name": "s3_object_key", "type": "STRING", "mode": "NULLABLE"},


### PR DESCRIPTION
After our most recent prod push we stopped inserting new data into bigquery due to errors such as:
```
msg: "failed into insert row: {'index': 0, 'errors': [{'reason': 'invalid', 'location': 'metadata.build', 'debugInfo': '', 'message': 'no such field.'}]}"
```

The error is happening now because the bigquery library switched to raising missing fields as errors instead of ignoing them. The fields in question come from https://github.com/mozilla-releng/buildhub2/blob/0a6a5b9cb24724bff8018bcdf5531fa21ade92a7/buildhub/main/models.py#L81, which is built out of the dockerflow version info (https://buildhub.moz.tools/__version__). Adding these new fields to it should fix the issues.