### PR TITLE
Strip away metadata that the bigquery table doesn't know about

### DIFF
--- a/buildhub/main/models.py
+++ b/buildhub/main/models.py
@@ -195,6 +195,10 @@ def send_to_elasticsearch(sender, instance, **kwargs):
 @receiver(post_save, sender=Build)
 def send_to_bigquery(sender, instance, **kwargs):
     doc = instance.to_dict()
+    valid_metadata_keys = ["commit", "version", "source", "build"]
+    doc["metadata"] = {
+        k: v for k, v in doc["metadata"].items() if k in valid_metadata_keys
+    }
     # The Python BigQuery library includes a retry mechanism for transient
     # errors. Search https://googleapis.dev/python/bigquery/latest under
     # google.cloud.bigquery.retry.DEFAULT_RETRY for more details.


### PR DESCRIPTION
This is another fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1666260 - where we're failing to insert to bigquery because there's new fields in `metadata`. This adds a explicit step that removes anything that isn't in the bigquery table schema, which should fix the current issue, and futureproof us.