### PR TITLE
Reduce bigquery rebuild chunk size to what we actual use

### DIFF
--- a/buildhub/settings.py
+++ b/buildhub/settings.py
@@ -192,7 +192,7 @@ class BigQuery:
     BQ_TABLE_ID = values.Value("builds")
 
     BQ_REBUILD_MAX_ERROR_COUNT = values.IntegerValue(1000)
-    BQ_REBUILD_CHUNK_SIZE = values.IntegerValue(10000)
+    BQ_REBUILD_CHUNK_SIZE = values.IntegerValue(1000)
 
 
 class OptionalDatabaseURLValue(values.DatabaseURLValue):


### PR DESCRIPTION
The current default of 10,000 ends up erroring out.